### PR TITLE
Integrate MediaPipe face detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Reconhecimento Facial
 
 Este projeto detecta rostos em imagens usando Python 3 e o modelo Haar Cascade do OpenCV.
+Opcionalmente, é possível utilizar o modelo **MediaPipe-Face-Detection** da Hugging Face para auxiliar na detecção.
 Também é possível gerar uma legenda da imagem utilizando um modelo de linguagem
 da Hugging Face via API.
 
@@ -20,6 +21,10 @@ da Hugging Face via API.
 2. Você pode executar a detecção diretamente:
    ```
    python3 face_detection.py --image caminho/para/imagem.jpg --output saida.jpg
+   ```
+   Para utilizar o modelo da Hugging Face adicione a opção `--hf`:
+   ```
+   python3 face_detection.py --image caminho/para/imagem.jpg --hf
    ```
 3. Para uma experiência interativa com menu e opção de gerar legendas via LLM,
    execute:

--- a/app.py
+++ b/app.py
@@ -16,8 +16,9 @@ def menu() -> None:
         if choice == "1":
             image = input("Caminho da imagem: ").strip()
             output = input("Arquivo de saida [output.jpg]: ").strip() or "output.jpg"
+            use_hf = input("Usar modelo da HuggingFace? [n]: ").strip().lower() == "s"
             try:
-                qtd = detect_faces(image, output)
+                qtd = detect_faces(image, output, use_hf=use_hf)
                 print(f"Detectado(s) {qtd} rosto(s). Resultado salvo em {output}")
             except Exception as exc:
                 print(f"Erro: {exc}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python
 requests
 huggingface_hub
+qai_hub_models


### PR DESCRIPTION
## Summary
- allow optional MediaPipe Face Detection model
- prompt for HF model in CLI menu
- mention new feature in docs
- add `qai_hub_models` to requirements

## Testing
- `python3 face_detection.py --help`
- `python3 -m py_compile face_detection.py app.py llm_service.py`
- `pip install opencv-python-headless` *(passed)*
- `pip install qai_hub_models` *(failed: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68556ba80718832aa61a965be74aa5ca