### PR TITLE
Add HF face detection model via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Este projeto detecta rostos em imagens usando Python 3 e o modelo Haar Cascade do OpenCV.
 Opcionalmente, é possível utilizar o modelo **MediaPipe-Face-Detection** da Hugging Face para auxiliar na detecção.
+O endereço da API utilizada deve ser definido pela variável `HF_FACE_DETECTION_URL` em um arquivo `.env`.
 Também é possível gerar uma legenda da imagem utilizando um modelo de linguagem
 da Hugging Face via API.
 
@@ -36,6 +37,7 @@ da Hugging Face via API.
    ```
    HUGGINGFACE_TOKEN=seu_token_aqui
    HF_API_URL=https://api-inference.huggingface.co/models/nlpconnect/vit-gpt2-image-captioning
+   HF_FACE_DETECTION_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
    ```
-   O token é obrigatório para a geração de legendas via API da Hugging Face.
+   O token é obrigatório para as chamadas de API da Hugging Face, tanto para gerar legendas quanto para a detecção de rostos.
 4. O script salva `saida.jpg` com retângulos ao redor dos rostos detectados.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 opencv-python
 requests
 huggingface_hub
-qai_hub_models
 python-dotenv


### PR DESCRIPTION
## Summary
- fetch the face detection model from HuggingFace inference API
- configure HF_FACE_DETECTION_URL in `.env`
- document new variable and remove unused dependency

## Testing
- `python -m py_compile face_detection.py llm_service.py app.py`
- `python face_detection.py --image test.jpg --output out.jpg`

------
https://chatgpt.com/codex/tasks/task_e_68557234f0b8832ab7c3afea34a6c1b3