### PR TITLE
Add YOLOv8 detection option

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-HF_FACE_DETECTION_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
+HF_MEDIAPIPE_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
+HF_YOLOV8_URL=https://api-inference.huggingface.co/models/arnabdhar/YOLOv8-Face-Detection

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reconhecimento Facial
 
 Este projeto detecta rostos em imagens usando Python 3 e o modelo Haar Cascade do OpenCV.
-Opcionalmente, é possível utilizar o modelo **MediaPipe-Face-Detection** da Hugging Face para auxiliar na detecção.
-O endereço da API utilizada deve ser definido pela variável `HF_FACE_DETECTION_URL` em um arquivo `.env`.
+Opcionalmente, é possível utilizar os modelos **MediaPipe-Face-Detection** ou **YOLOv8-Face-Detection** da Hugging Face para auxiliar na detecção.
+Os endereços das APIs devem ser definidos pelas variáveis `HF_MEDIAPIPE_URL` e `HF_YOLOV8_URL` em um arquivo `.env`.
 Também é possível gerar uma legenda da imagem utilizando um modelo de linguagem
 da Hugging Face via API.
 
@@ -24,17 +24,20 @@ da Hugging Face via API.
    ```
    python3 face_detection.py --image caminho/para/imagem.jpg --output saida.jpg
    ```
-   Para utilizar o modelo da Hugging Face adicione a opção `--hf`:
+   Para utilizar um dos modelos da Hugging Face adicione a opção `--hf`. O
+   modelo padrão é o `mediapipe`, mas é possível usar o YOLOv8 passando
+   `--model yolov8`:
    ```
-   python3 face_detection.py --image caminho/para/imagem.jpg --hf
+   python3 face_detection.py --image caminho/para/imagem.jpg --hf --model yolov8
    ```
 3. Para uma experiência interativa com menu e opção de gerar legendas via LLM,
    execute:
    ```
    python3 app.py
    ```
-   Antes de executar, crie um arquivo `.env` na raiz com o conteúdo:
+   Antes de executar, crie um arquivo `.env` na raiz com o conteúdo, por exemplo:
    ```
-   HF_FACE_DETECTION_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
+   HF_MEDIAPIPE_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
+   HF_YOLOV8_URL=https://api-inference.huggingface.co/models/arnabdhar/YOLOv8-Face-Detection
    ```
 4. O script salva `saida.jpg` com retângulos ao redor dos rostos detectados.

--- a/app.py
+++ b/app.py
@@ -14,7 +14,8 @@ def menu() -> None:
         print("\n=== Menu ===")
         print("1 - Detectar rostos (OpenCV)")
         print("2 - Detectar rostos com MediaPipe (HuggingFace)")
-        print("3 - Gerar legenda via LLM")
+        print("3 - Detectar rostos com YOLOv8 (HuggingFace)")
+        print("4 - Gerar legenda via LLM")
         print("0 - Sair")
         choice = input("Escolha uma opcao: ").strip()
 
@@ -30,11 +31,19 @@ def menu() -> None:
             image = input("Caminho da imagem: ").strip()
             output = input("Arquivo de saida [output.jpg]: ").strip() or "output.jpg"
             try:
-                qtd = detect_faces(image, output, use_hf=True)
+                qtd = detect_faces(image, output, use_hf=True, hf_model="mediapipe")
                 print(f"Detectado(s) {qtd} rosto(s). Resultado salvo em {output}")
             except Exception as exc:
                 print(f"Erro: {exc}")
         elif choice == "3":
+            image = input("Caminho da imagem: ").strip()
+            output = input("Arquivo de saida [output.jpg]: ").strip() or "output.jpg"
+            try:
+                qtd = detect_faces(image, output, use_hf=True, hf_model="yolov8")
+                print(f"Detectado(s) {qtd} rosto(s). Resultado salvo em {output}")
+            except Exception as exc:
+                print(f"Erro: {exc}")
+        elif choice == "4":
             image = input("Caminho da imagem: ").strip()
             try:
                 caption = generate_caption(image)


### PR DESCRIPTION
## Summary
- allow choosing MediaPipe or YOLOv8 face detection models
- show both HF models in the menu
- document the new options and environment variables
- update `.env` example

## Testing
- `python -m py_compile app.py face_detection.py llm_service.py`
- `python face_detection.py --help | head` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_685577e7e658832ab5886b625abeb2d8