### PR TITLE
Switch to offline HuggingFace models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Reconhecimento Facial
 
 Este projeto detecta rostos em imagens usando Python 3 e o modelo Haar Cascade do OpenCV.
-Opcionalmente, é possível utilizar os modelos **MediaPipe-Face-Detection** ou **YOLOv8-Face-Detection** da Hugging Face para auxiliar na detecção.
-Os endereços das APIs devem ser definidos pelas variáveis `HF_MEDIAPIPE_URL` e `HF_YOLOV8_URL` em um arquivo `.env`.
+Opcionalmente, é possível utilizar os modelos **MediaPipe-Face-Detection** ou **YOLOv8-Face-Detection** da Hugging Face localmente para auxiliar na detecção.
+Os modelos são baixados automaticamente do Hub na primeira execução, não sendo necessário configurar URLs de API.
 Também é possível gerar uma legenda da imagem utilizando um modelo de linguagem
-da Hugging Face via API.
+da Hugging Face de forma local.
 
 ## Requisitos
 
 - Python 3
 - opencv-python (pode ser instalado com `pip install opencv-python`)
-- requests
+- mediapipe
+- ultralytics
+- torch
+- transformers
 - huggingface_hub
 - python-dotenv
 
@@ -34,10 +37,5 @@ da Hugging Face via API.
    execute:
    ```
    python3 app.py
-   ```
-   Antes de executar, crie um arquivo `.env` na raiz com o conteúdo, por exemplo:
-   ```
-   HF_MEDIAPIPE_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
-   HF_YOLOV8_URL=https://api-inference.huggingface.co/models/arnabdhar/YOLOv8-Face-Detection
    ```
 4. O script salva `saida.jpg` com retângulos ao redor dos rostos detectados.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 opencv-python
-requests
+mediapipe
+ultralytics
+torch
+transformers
 huggingface_hub
 python-dotenv


### PR DESCRIPTION
## Summary
- use `mediapipe` and `YOLOv8` models from HuggingFace locally for face detection
- load image caption model locally using `transformers`
- update dependencies
- document new offline workflow

## Testing
- `python -m py_compile face_detection.py llm_service.py app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68557a1797c0832aa61bcb8932f494e1