### PR TITLE
Update torch version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ da Hugging Face de forma local.
 - opencv-python (pode ser instalado com `pip install opencv-python`)
 - mediapipe
 - ultralytics
-- torch
+- torch >=2.6 (necessário devido às proteções do `transformers` contra CVE-2025-32434)
 - transformers
 - huggingface_hub
 - python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python
 mediapipe
 ultralytics
-torch
+torch>=2.6
 transformers
 huggingface_hub
 python-dotenv


### PR DESCRIPTION
## Summary
- specify `torch>=2.6` in requirements
- document PyTorch 2.6+ in README with note about `transformers` CVE-2025-32434 protections

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68557f8e2aec832aa3860a1f3c3b3002