### PR TITLE
Document env vars and prune unused settings

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
-HF_MEDIAPIPE_URL=https://api-inference.huggingface.co/models/qualcomm/MediaPipe-Face-Detection
-HF_YOLOV8_URL=https://api-inference.huggingface.co/models/arnabdhar/YOLOv8-Face-Detection
+# Configure suas variáveis de ambiente aqui, se necessário

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ O projeto inclui uma interface de linha de comando unificada e testes automatiza
 
 Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
 
+## Variáveis de ambiente
+
+- `MEDIAPIPE_REPO`: repositório do modelo MediaPipe (padrão: `qualcomm/MediaPipe-Face-Detection`).
+- `YOLOV8_REPO`: repositório do modelo YOLOv8 (padrão: `jaredthejelly/yolov8s-face-detection`).
+- `HF_CAPTION_MODEL`: modelo de legenda (padrão: `nlpconnect/vit-gpt2-image-captioning`).
+
 ## Requisitos
 
 - Python 3


### PR DESCRIPTION
## Summary
- remove unused HF url variables from `.env`
- explain which environment variables can tweak local models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558874d610832a8b4e9f4c8b07cb42