### PR TITLE
Use .env for model repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Os modelos são baixados automaticamente do Hub na primeira execução, não sen
 Também é possível gerar uma legenda da imagem utilizando um modelo de linguagem da Hugging Face de forma local.
 
 O projeto inclui uma interface de linha de comando unificada e testes automatizados com `pytest`. Modelos alternativos podem ser definidos pelas variáveis de ambiente `MEDIAPIPE_REPO`, `YOLOV8_REPO`, `HF_CAPTION_MODEL` e `OBSTRUCTION_MODEL_REPO`.
+Todas essas variáveis podem ser configuradas em um arquivo `.env` na raiz do projeto e serão carregadas automaticamente.
 
 Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
 

--- a/face_detection.py
+++ b/face_detection.py
@@ -3,6 +3,12 @@ import logging
 import os
 from typing import Optional
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pass
+
 import cv2
 try:
     from huggingface_hub import hf_hub_download

--- a/llm_service.py
+++ b/llm_service.py
@@ -4,6 +4,12 @@ import logging
 import os
 
 try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pass
+
+try:
     import torch
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     torch = None

--- a/obstruction_detection.py
+++ b/obstruction_detection.py
@@ -2,6 +2,12 @@ import logging
 import os
 
 try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pass
+
+try:
     from transformers import pipeline
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     pipeline = None


### PR DESCRIPTION
## Summary
- load `.env` in all modules so model repo names come from env vars
- mention automatic loading of env vars in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a8ad1df8832a9a87b6fefda94c76