### PR TITLE
Fix color space conversion in webcam recognition

### DIFF
--- a/recognition.py
+++ b/recognition.py
@@ -120,7 +120,8 @@ def recognize_webcam() -> None:
         ret, frame = cap.read()
         if not ret:
             break
-        rgb = frame[:, :, ::-1]
+        # Convert BGR captured by OpenCV to RGB for face_recognition
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         locations = face_recognition.face_locations(rgb)
         encodings = face_recognition.face_encodings(rgb, locations)
         for (top, right, bottom, left), face_enc in zip(locations, encodings):


### PR DESCRIPTION
## Summary
- convert webcam frames from BGR to RGB before calling `face_recognition`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bae4af88832abfe1426f609516c3