### PR TITLE
Improve webcam capture error reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,8 +73,10 @@ def menu() -> None:
         elif choice == options[5]:
             name = input("Nome da pessoa: ").strip()
             try:
-                register_person_webcam(name)
-                print("Pessoa cadastrada")
+                if register_person_webcam(name):
+                    print("Pessoa cadastrada")
+                else:
+                    print("Erro ao capturar imagem da webcam")
             except Exception as exc:
                 print(f"Erro ao cadastrar: {exc}")
         elif choice == options[6]:

--- a/recognition.py
+++ b/recognition.py
@@ -85,13 +85,19 @@ def register_person(name: str, image_path: str) -> None:
         conn.commit()
 
 
-def register_person_webcam(name: str) -> None:
-    """Capture image from webcam and register person in the database."""
+def register_person_webcam(name: str) -> bool:
+    """Capture image from webcam and register person in the database.
+
+    Returns ``True`` when the capture and registration succeed, otherwise
+    ``False``. This allows callers to present a meaningful error message
+    instead of always reporting success.
+    """
     tmp = f"/tmp/{name.replace(' ', '_')}.jpg"
     if not capture_from_webcam(tmp):
-        return
+        return False
     try:
         register_person(name, tmp)
+        return True
     finally:
         if os.path.exists(tmp):
             os.remove(tmp)


### PR DESCRIPTION
## Summary
- return success from `register_person_webcam`
- show an error when webcam capture fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c4212958832ab13e2f2b33dfb9a3