### PR TITLE
Fix CLI imports for nested execution

### DIFF
--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -3,6 +3,13 @@ import logging
 import os
 import time
 
+if __package__ is None or __package__ == "":
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+    __package__ = "reconhecimento_facial"
+
 from dotenv import load_dotenv
 import questionary
 

--- a/reconhecimento_facial/face_detection.py
+++ b/reconhecimento_facial/face_detection.py
@@ -3,6 +3,13 @@ import logging
 import os
 from typing import Optional, Tuple, List, Dict
 
+if __package__ is None or __package__ == "":
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+    __package__ = "reconhecimento_facial"
+
 try:
     from dotenv import load_dotenv
     load_dotenv()

--- a/reconhecimento_facial/recognition.py
+++ b/reconhecimento_facial/recognition.py
@@ -7,6 +7,13 @@ from importlib.util import find_spec
 import cv2
 import os
 
+if __package__ is None or __package__ == "":
+    import pathlib
+    import sys as _sys
+
+    _sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+    __package__ = "reconhecimento_facial"
+
 
 def _patch_face_recognition_models() -> None:
     """Replace the face_recognition_models package to avoid deprecated

--- a/reconhecimento_facial/web_app.py
+++ b/reconhecimento_facial/web_app.py
@@ -1,4 +1,12 @@
 from flask import Flask, request, jsonify
+
+if __package__ is None or __package__ == "":
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+    __package__ = "reconhecimento_facial"
+
 from reconhecimento_facial.face_detection import detect_faces
 from reconhecimento_facial.llm_service import generate_caption
 from reconhecimento_facial.obstruction_detection import detect_obstruction


### PR DESCRIPTION
## Summary
- allow running modules directly from the package directory

## Testing
- `pytest -q`
- `python3 app.py --help`
- `python3 face_detection.py --help`
- `python3 recognition.py --help`
- `python3 web_app.py --help` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855edf4713c832a9ddeeb524915bdd9