### PR TITLE
Atualiza .env com modelos usados

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ YOLOV8_REPO=jaredthejelly/yolov8s-face-detection
 HF_CAPTION_MODEL=nlpconnect/vit-gpt2-image-captioning
 OBSTRUCTION_MODEL_REPO=dima806/face_obstruction_image_detection
 EMOTION_MODEL_REPO=nateraw/fer-vit-base
-# DEMOGRAPHICS_MODEL_REPO=nateraw/age-gender-estimation
+DEMOGRAPHICS_MODEL_REPO=nateraw/age-gender-estimation
+FACEXFORMER_REPO=kartiknarayan/facexformer
 POSTGRES_DSN=postgresql://user:pass@localhost:5432/face_db

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas 
 - `HF_CAPTION_MODEL`: modelo de legenda (padrão: `nlpconnect/vit-gpt2-image-captioning`).
 - `OBSTRUCTION_MODEL_REPO`: modelo para detectar obstrução facial (padrão: `dima806/face_obstruction_image_detection`).
 - `EMOTION_MODEL_REPO`: modelo de classificação de emoções (padrão: `nateraw/fer-vit-base`).
-- `DEMOGRAPHICS_MODEL_REPO`: modelo para estimar sexo, idade e etnia (padrão: `kartiknarayan/facexformer`).
+- `DEMOGRAPHICS_MODEL_REPO`: modelo para estimar sexo, idade e etnia (padrão: `nateraw/age-gender-estimation`).
+- `FACEXFORMER_REPO`: repositório do FaceXFormer usado quando `DEMOGRAPHICS_MODEL_REPO` é `kartiknarayan/facexformer`.
 - Para utilizar o FaceXFormer, defina `DEMOGRAPHICS_MODEL_REPO=kartiknarayan/facexformer` no ambiente.
 - `POSTGRES_DSN`: string de conexão do PostgreSQL usada por `db.py`.
 

--- a/reconhecimento_facial/facexformer/inference.py
+++ b/reconhecimento_facial/facexformer/inference.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import torch
 from PIL import Image
 from torchvision import transforms
@@ -43,9 +44,8 @@ def _load_model() -> None:
         return
     device = "cuda" if torch.cuda.is_available() else "cpu"
     try:
-        weight_path = hf_hub_download(
-            repo_id="kartiknarayan/facexformer", filename="ckpts/model.pt"
-        )
+        repo = os.getenv("FACEXFORMER_REPO", "kartiknarayan/facexformer")
+        weight_path = hf_hub_download(repo, "ckpts/model.pt")
     except Exception as exc:  # noqa: BLE001
         logger.error("failed to download facexformer weights: %s", exc)
         return


### PR DESCRIPTION
## Summary
- adicione modelos faltantes no arquivo `.env.example`
- documente variáveis no README
- torne o FaceXFormer configurável pelo env `FACEXFORMER_REPO`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855fb3bd3a0832a9725df12b4835904