### PR TITLE
Add DeepFace backend option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,5 @@ YOLOV8_REPO=jaredthejelly/yolov8s-face-detection
 HF_CAPTION_MODEL=nlpconnect/vit-gpt2-image-captioning
 OBSTRUCTION_MODEL_REPO=dima806/face_obstruction_image_detection
 FACEXFORMER_REPO=kartiknarayan/facexformer
+DEMOGRAPHICS_BACKEND=facexformer
 POSTGRES_DSN=postgresql://user:pass@localhost:5432/face_db

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Para utilizar o menu interativo:
 python3 -m reconhecimento_facial.app
 ```
 
+Dentro de **Outros**, utilize a op\u00e7\u00e3o *Selecionar backend demogr\u00e1fico* para alternar entre FaceXFormer e DeepFace.
+
 Você também pode executar comandos específicos diretamente pela CLI:
 
 ```bash
@@ -48,7 +50,7 @@ O programa principal (`app.py`) apresenta três categorias principais:
 
 1. **Detecção** – para identificar rostos ou possíveis obstruções nas imagens.
 2. **Reconhecimento** – para cadastrar pessoas e fazer reconhecimento facial via webcam.
-3. **Outros** – onde é possível gerar legendas para imagens usando um modelo de linguagem.
+3. **Outros** – onde é possível gerar legendas para imagens usando um modelo de linguagem e escolher a biblioteca de análise demográfica.
 
 ## Funcionalidades
 
@@ -56,6 +58,7 @@ O programa principal (`app.py`) apresenta três categorias principais:
 - Cadastro de pessoas e reconhecimento em tempo real.
 - Detecção de obstrução facial.
 - Detecção de sexo, idade, etnia e cor de pele na webcam.
+- Escolha entre FaceXFormer ou DeepFace para análise demográfica.
 - Opção de desfocar rostos para privacidade.
 - Armazenamento de resultados em PostgreSQL (via `POSTGRES_DSN`).
 - Interface web em Flask e Dockerfile para facilitar a execução.
@@ -69,6 +72,7 @@ Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas 
 - `HF_CAPTION_MODEL`: modelo de legenda (padrão: `nlpconnect/vit-gpt2-image-captioning`).
 - `OBSTRUCTION_MODEL_REPO`: modelo para detectar obstrução facial (padrão: `dima806/face_obstruction_image_detection`).
 - `FACEXFORMER_REPO`: repositório do FaceXFormer utilizado para estimar sexo, idade, etnia e cor de pele.
+- `DEMOGRAPHICS_BACKEND`: biblioteca usada para estimar sexo e idade (`facexformer` ou `deepface`).
 - `POSTGRES_DSN`: string de conexão do PostgreSQL usada por `db.py`.
 
 ## Requisitos
@@ -81,6 +85,7 @@ Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas 
 - transformers
 - huggingface_hub
 - python-dotenv
+- deepface
 
 ## Testes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "numpy",
     "flask",
     "questionary",
+    "deepface",
     "face_recognition; platform_system != 'Windows'",  # optional
     "psycopg2-binary",
 ]

--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -20,6 +20,7 @@ from reconhecimento_facial.llm_service import generate_caption
 from reconhecimento_facial.obstruction_detection import detect_obstruction
 from reconhecimento_facial.recognition import recognize_webcam, register_person_webcam
 from reconhecimento_facial.preload import preload_models
+from reconhecimento_facial.demographics_detection import set_backend
 
 logger = logging.getLogger(__name__)
 
@@ -94,9 +95,25 @@ def _recognition_menu() -> None:
             recognize_webcam()
 
 
+def _backend_menu() -> None:
+    options = ["FaceXFormer", "DeepFace", "Voltar"]
+    while True:
+        choice = questionary.select(
+            "Biblioteca para analise demografica", choices=options
+        ).ask()
+        if choice in (None, "Voltar"):
+            break
+        if choice == options[0]:
+            set_backend("facexformer")
+        elif choice == options[1]:
+            set_backend("deepface")
+        print(f"Backend selecionado: {choice}")
+
+
 def _other_menu() -> None:
     options = [
         "Gerar legenda via LLM",
+        "Selecionar backend demogr\u00e1fico",
         "Voltar",
     ]
     while True:
@@ -111,6 +128,8 @@ def _other_menu() -> None:
                 print(f"Legenda gerada: {caption}")
             except Exception as exc:
                 print(f"Erro ao gerar legenda: {exc}")
+        elif choice == options[1]:
+            _backend_menu()
 
 
 def menu() -> None:

--- a/reconhecimento_facial/deepface_integration.py
+++ b/reconhecimento_facial/deepface_integration.py
@@ -1,0 +1,47 @@
+import logging
+
+try:
+    from deepface import DeepFace
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    DeepFace = None
+
+logger = logging.getLogger(__name__)
+_model_loaded = False
+
+
+def _load_model() -> None:
+    """Preload DeepFace models."""
+    global _model_loaded
+    if _model_loaded or DeepFace is None:
+        return
+    try:
+        DeepFace.build_model("Age")
+        DeepFace.build_model("Gender")
+        DeepFace.build_model("Race")
+        _model_loaded = True
+    except Exception as exc:  # noqa: BLE001
+        logger.error("failed to load DeepFace models: %s", exc)
+
+
+def detect_demographics(image_path: str) -> dict:
+    """Detect age, gender and ethnicity using DeepFace."""
+    _load_model()
+    if DeepFace is None:
+        raise RuntimeError("DeepFace not installed")
+    try:
+        res = DeepFace.analyze(
+            img_path=image_path,
+            actions=["age", "gender", "race"],
+            enforce_detection=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("failed to analyze face with DeepFace: %s", exc)
+        raise
+    if isinstance(res, list):
+        res = res[0]
+    return {
+        "age": str(res.get("age", "")),
+        "gender": str(res.get("gender", "")).lower(),
+        "ethnicity": str(res.get("dominant_race", "")),
+        "skin": str(res.get("dominant_race", "")),
+    }

--- a/reconhecimento_facial/demographics_detection.py
+++ b/reconhecimento_facial/demographics_detection.py
@@ -1,11 +1,22 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+_backend = os.getenv("DEMOGRAPHICS_BACKEND", "facexformer")
 
 
-def detect_demographics(image) -> dict:
+def set_backend(backend: str) -> None:
+    """Define which backend will be used for demographics detection."""
+    global _backend
+    _backend = backend
+
+
+def detect_demographics(image: str) -> dict:
     """Return gender, age, ethnicity and skin color labels from the image."""
     try:
+        if _backend == "deepface":
+            from .deepface_integration import detect_demographics as dp_detect
+            return dp_detect(image)
         from .facexformer.inference import detect_demographics as fx_detect
         return fx_detect(image)
     except Exception as exc:  # noqa: BLE001

--- a/reconhecimento_facial/preload.py
+++ b/reconhecimento_facial/preload.py
@@ -1,6 +1,8 @@
 # Helper to preload models for the interactive menu
 from __future__ import annotations
 
+import os
+
 from reconhecimento_facial.llm_service import _load_pipe as _load_llm
 from reconhecimento_facial.obstruction_detection import _load_pipe as _load_obstruction
 from reconhecimento_facial.facexformer.inference import _load_model as _load_facexformer
@@ -19,6 +21,11 @@ def preload_models() -> None:
         pass
 
     try:
-        _load_facexformer()
+        backend = os.getenv("DEMOGRAPHICS_BACKEND", "facexformer")
+        if backend == "deepface":
+            from reconhecimento_facial.deepface_integration import _load_model as _load_deepface
+            _load_deepface()
+        else:
+            _load_facexformer()
     except Exception:
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ python-dotenv
 numpy
 flask
 questionary
+deepface
 face_recognition; platform_system != 'Windows'
 psycopg2-binary

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -7,16 +7,33 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import reconhecimento_facial.demographics_detection as dd
 
 
-def test_detect_demographics(monkeypatch):
+def test_detect_demographics_facexformer(monkeypatch):
     dummy = types.ModuleType('dummy')
     dummy.detect_demographics = lambda img: {
         'gender': 'male', 'age': '30', 'ethnicity': 'asian', 'skin': 'light'
     }
     monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer.inference', dummy)
+    dd.set_backend('facexformer')
     result = dd.detect_demographics('any.jpg')
     assert result == {
         'gender': 'male',
         'age': '30',
         'ethnicity': 'asian',
         'skin': 'light'
+    }
+
+
+def test_detect_demographics_deepface(monkeypatch):
+    dummy = types.ModuleType('dummy2')
+    dummy.detect_demographics = lambda img: {
+        'gender': 'female', 'age': '25', 'ethnicity': 'white', 'skin': 'fair'
+    }
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.deepface_integration', dummy)
+    dd.set_backend('deepface')
+    result = dd.detect_demographics('any.jpg')
+    assert result == {
+        'gender': 'female',
+        'age': '25',
+        'ethnicity': 'white',
+        'skin': 'fair'
     }


### PR DESCRIPTION
## Summary
- support DeepFace for demographic analysis
- allow switching backend through a new menu option
- load the chosen backend during model preload
- document new environment variable and add DeepFace to requirements
- update tests for new backend selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685602e25dec832a81b41b70185e6510