### PR TITLE
Fix DeepFace model loading for demographic analysis

### DIFF
--- a/reconhecimento_facial/deepface_integration.py
+++ b/reconhecimento_facial/deepface_integration.py
@@ -28,9 +28,9 @@ def _load_model() -> None:
             except Exception:
                 pass
 
-        DeepFace.build_model("Age")
-        DeepFace.build_model("Gender")
-        DeepFace.build_model("Race")
+        DeepFace.build_model("Age", "facial_attribute")
+        DeepFace.build_model("Gender", "facial_attribute")
+        DeepFace.build_model("Race", "facial_attribute")
         _model_loaded = True
     except Exception as exc:  # noqa: BLE001
         logger.error("failed to load DeepFace models: %s", exc)


### PR DESCRIPTION
## Summary
- correct DeepFace `build_model` calls for demographic models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685609fa2370832a9002c6de3bdf7e1d