### PR TITLE
Add audio file translation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ python3 -m reconhecimento_facial.face_detection --image caminho/para/imagem.jpg 
 python3 -m reconhecimento_facial.app detect --image caminho/para/imagem.jpg --model yolov8
 python3 -m reconhecimento_facial.recognition --webcam
 python3 -m reconhecimento_facial.whisper_translation --model base --chunk 5 --webcam
+python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --expected "texto esperado"
 ```
 
 ## Organização dos menus

--- a/reconhecimento_facial/__init__.py
+++ b/reconhecimento_facial/__init__.py
@@ -9,10 +9,22 @@ def translate_microphone(*a, **kw):  # pragma: no cover - wrapper for lazy impor
     return _tm(*a, **kw)
 
 
+def translate_file(*a, **kw):  # pragma: no cover - wrapper for lazy import
+    from .whisper_translation import translate_file as _tf
+
+    return _tf(*a, **kw)
+
+
 def translate_webcam(*a, **kw):  # pragma: no cover - wrapper for lazy import
     from .whisper_translation import translate_webcam as _tw
 
     return _tw(*a, **kw)
 
 
-__all__ = ["get_device", "set_device", "translate_microphone", "translate_webcam"]
+__all__ = [
+    "get_device",
+    "set_device",
+    "translate_microphone",
+    "translate_file",
+    "translate_webcam",
+]

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import reconhecimento_facial.whisper_translation as wt
+
+
+def test_translate_file(monkeypatch):
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hello"})
+    monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
+    assert wt.translate_file("foo.wav") == "hello"
+
+
+def test_main_with_expected(monkeypatch, capsys):
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
+    monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
+    wt.main(["--file", "foo.wav", "--expected", "hi"])
+    captured = capsys.readouterr()
+    assert "hi" in captured.out
+    assert "Tradu\u00e7\u00e3o confere" in captured.out


### PR DESCRIPTION
## Summary
- allow translating audio files instead of mic input
- compare translation with expected text
- expose `translate_file` in package API
- document new CLI usage
- add tests for new translation feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573471bbd4832a957e048c82a17dc3