### PR TITLE
Add translation language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Você também pode executar comandos específicos diretamente pela CLI:
 python3 -m reconhecimento_facial.face_detection --image caminho/para/imagem.jpg --output saida.jpg
 python3 -m reconhecimento_facial.app detect --image caminho/para/imagem.jpg --model yolov8
 python3 -m reconhecimento_facial.recognition --webcam
-python3 -m reconhecimento_facial.whisper_translation --model base --chunk 5 --webcam
-python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --expected "texto esperado"
+python3 -m reconhecimento_facial.whisper_translation --model base --chunk 5 --src pt --tgt en --webcam
+python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --src pt --tgt en --expected "texto esperado"
 ```
 
 ## Organização dos menus
@@ -71,6 +71,7 @@ O programa principal (`app.py`) apresenta cinco categorias principais:
 - Armazenamento de resultados em PostgreSQL (via `POSTGRES_DSN`).
 - Interface web em Flask e Dockerfile para facilitar a execução.
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
+- É possível escolher os idiomas de entrada e saída para a tradução.
 
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
 

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -8,15 +8,17 @@ import reconhecimento_facial.whisper_translation as wt
 
 
 def test_translate_file(monkeypatch):
-    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hello"})
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "ola"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    assert wt.translate_file("foo.wav") == "hello"
+    monkeypatch.setattr(wt, "_translate_text", lambda t, s, d: "hello")
+    assert wt.translate_file("foo.wav", source_lang="pt", target_lang="en") == "hello"
 
 
 def test_main_with_expected(monkeypatch, capsys):
-    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "oi"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    wt.main(["--file", "foo.wav", "--expected", "hi"])
+    monkeypatch.setattr(wt, "_translate_text", lambda t, s, d: "hi")
+    wt.main(["--file", "foo.wav", "--expected", "hi", "--src", "pt", "--tgt", "en"])
     captured = capsys.readouterr()
     assert "hi" in captured.out
     assert "Tradu\u00e7\u00e3o confere" in captured.out


### PR DESCRIPTION
## Summary
- allow choosing source/target languages
- run translation concurrently with every recognition option
- expose language options in CLI and README
- update tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685736e3b088832a9bb007b5c19da0cc