### PR TITLE
Add Whisper translation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python3 -m reconhecimento_facial.app detect --image caminho/para/imagem.jpg --mo
 python3 -m reconhecimento_facial.recognition --webcam
 python3 -m reconhecimento_facial.whisper_translation --model base --chunk 5 --src pt --tgt en --webcam
 python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --src pt --tgt en --expected "texto esperado"
+python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --whisper --src pt
 ```
 
 ## Organização dos menus
@@ -72,6 +73,7 @@ O programa principal (`app.py`) apresenta cinco categorias principais:
 - Interface web em Flask e Dockerfile para facilitar a execução.
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
 - É possível escolher os idiomas de entrada e saída para a tradução.
+- Para usar a tradução direta do Whisper para inglês, adicione a opção `--whisper`.
 
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
 

--- a/reconhecimento_facial/__init__.py
+++ b/reconhecimento_facial/__init__.py
@@ -15,6 +15,12 @@ def translate_file(*a, **kw):  # pragma: no cover - wrapper for lazy import
     return _tf(*a, **kw)
 
 
+def whisper_translate_file(*a, **kw):  # pragma: no cover - wrapper for lazy import
+    from .whisper_translation import whisper_translate_file as _wtf
+
+    return _wtf(*a, **kw)
+
+
 def translate_webcam(*a, **kw):  # pragma: no cover - wrapper for lazy import
     from .whisper_translation import translate_webcam as _tw
 
@@ -26,5 +32,6 @@ __all__ = [
     "set_device",
     "translate_microphone",
     "translate_file",
+    "whisper_translate_file",
     "translate_webcam",
 ]

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -14,6 +14,12 @@ def test_translate_file(monkeypatch):
     assert wt.translate_file("foo.wav", source_lang="pt", target_lang="en") == "hello"
 
 
+def test_whisper_translate_file(monkeypatch):
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
+    monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
+    assert wt.whisper_translate_file("foo.wav", model_name="base", source_lang="pt") == "hi"
+
+
 def test_main_with_expected(monkeypatch, capsys):
     dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "oi"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
@@ -22,3 +28,12 @@ def test_main_with_expected(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "hi" in captured.out
     assert "Tradu\u00e7\u00e3o confere" in captured.out
+
+
+def test_main_whisper_flag(monkeypatch, capsys):
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hello"})
+    monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
+    wt.main(["--file", "foo.wav", "--whisper", "--src", "pt"])
+    captured = capsys.readouterr()
+    assert "hello" in captured.out
+


### PR DESCRIPTION
## Summary
- allow direct Whisper translation with `--whisper`
- expose new `whisper_translate_file` helper
- document the `--whisper` flag in README
- test the new translation path

## Testing
- `pip install numpy`
- `pip install opencv-python-headless`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573d4dd7e8832a84e9698367f3f019