### PR TITLE
Suppress demographics error logs

### DIFF
--- a/reconhecimento_facial/demographics_detection.py
+++ b/reconhecimento_facial/demographics_detection.py
@@ -16,5 +16,5 @@ def detect_demographics(image: Any) -> dict:
         from .facexformer.inference import detect_demographics as fx_detect
         return fx_detect(image)
     except Exception as exc:  # noqa: BLE001
-        logger.error("error detecting demographics: %s", exc)
+        logger.debug("error detecting demographics: %s", exc)
         return {}


### PR DESCRIPTION
## Summary
- reduce log level for demographics detection failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685743de33ec832a8e8cbc19d8fbf5d0