### PR TITLE
Add translation target language option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ O programa principal (`app.py`) apresenta cinco categorias principais:
 - Armazenamento de resultados em PostgreSQL (via `POSTGRES_DSN`).
 - Interface web em Flask e Dockerfile para facilitar a execução.
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
-- É possível escolher o idioma de entrada; a tradução é sempre para o inglês.
+- É possível escolher os idiomas de entrada e saída (padrão: inglês).
 
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
 

--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -34,6 +34,7 @@ from reconhecimento_facial.whisper_translation import (
 logger = logging.getLogger(__name__)
 
 _src_lang = "pt"
+_dst_lang = "en"
 
 
 def _language_menu() -> None:
@@ -51,12 +52,27 @@ def _language_menu() -> None:
         _src_lang = langs[src]
 
 
+def _target_language_menu() -> None:
+    """Allow user to choose the target language for translation."""
+    global _dst_lang
+    langs = {
+        "English": "en",
+        "Português": "pt",
+        "Español": "es",
+        "Français": "fr",
+    }
+    names = list(langs.keys())
+    dst = questionary.select("Idioma de saída", choices=names).ask()
+    if dst:
+        _dst_lang = langs[dst]
+
+
 def _run_with_translation(func) -> None:
     """Execute a recognition function while running translation."""
     stop_event = threading.Event()
     thr = threading.Thread(
         target=translate_microphone,
-        args=(DEFAULT_WHISPER_MODEL, 5, stop_event, _src_lang, True),
+        args=(DEFAULT_WHISPER_MODEL, 5, stop_event, _src_lang, _dst_lang, True),
         daemon=True,
     )
     thr.start()
@@ -127,6 +143,7 @@ def _recognition_menu() -> None:
         if choice in (None, "Voltar"):
             break
         _language_menu()
+        _target_language_menu()
         if choice == options[0]:
             _run_with_translation(recognize_webcam)
         elif choice == options[1]:

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -10,7 +10,14 @@ import reconhecimento_facial.whisper_translation as wt
 def test_translate_file(monkeypatch):
     dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    assert wt.translate_file("foo.wav", source_lang="pt") == "hi"
+    assert wt.translate_file("foo.wav", source_lang="pt", target_lang="en") == "hi"
+
+
+def test_translate_file_other_lang(monkeypatch):
+    dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hola"})
+    monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
+    monkeypatch.setattr(wt, "_translate_text", lambda t, s, d: "bonjour")
+    assert wt.translate_file("foo.wav", source_lang="es", target_lang="fr") == "bonjour"
 
 
 def test_transcribe_file(monkeypatch):
@@ -22,13 +29,16 @@ def test_transcribe_file(monkeypatch):
 def test_whisper_translate_file(monkeypatch):
     dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    assert wt.whisper_translate_file("foo.wav", model_name="base", source_lang="pt") == "hi"
+    assert (
+        wt.whisper_translate_file("foo.wav", model_name="base", source_lang="pt", target_lang="en")
+        == "hi"
+    )
 
 
 def test_main_with_expected(monkeypatch, capsys):
     dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hi"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    wt.main(["--file", "foo.wav", "--expected", "hi", "--src", "pt"])
+    wt.main(["--file", "foo.wav", "--expected", "hi", "--src", "pt", "--dst", "en"])
     captured = capsys.readouterr()
     assert "hi" in captured.out
     assert "Tradu\u00e7\u00e3o confere" in captured.out
@@ -37,7 +47,7 @@ def test_main_with_expected(monkeypatch, capsys):
 def test_main_transcribe_flag(monkeypatch, capsys):
     dummy_model = types.SimpleNamespace(transcribe=lambda *a, **k: {"text": "hello"})
     monkeypatch.setattr(wt, "whisper", types.SimpleNamespace(load_model=lambda n: dummy_model))
-    wt.main(["--file", "foo.wav", "--transcribe", "--src", "pt"])
+    wt.main(["--file", "foo.wav", "--transcribe", "--src", "pt", "--dst", "en"])
     captured = capsys.readouterr()
     assert "hello" in captured.out
 


### PR DESCRIPTION
## Summary
- let users choose target translation language (default English)
- add target language selection in CLI and UI
- support external translation model via transformers
- update tests for new workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685745c49520832a95d7e85f10bab45b