### PR TITLE
Ensure DB dsn only from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ O programa principal (`app.py`) apresenta cinco categorias principais:
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
 - É possível escolher o idioma de entrada, traduzindo sempre para o inglês.
 
-Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`.
+Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`. A variável `POSTGRES_DSN` **deve** ser definida nesse arquivo caso queira usar o banco de dados.
 
 ## Variáveis de ambiente
 
@@ -85,7 +85,7 @@ Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas 
 - `FACEXFORMER_REPO`: repositório do FaceXFormer utilizado nas funções de demografia e `analyze_face`.
 - `WHISPER_MODEL`: modelo padrão do Whisper para tradução de áudio.
 - `RF_DEVICE`: define o dispositivo de processamento (`auto`, `cpu` ou `gpu`).
-- `POSTGRES_DSN`: string de conexão do PostgreSQL usada por `db.py`.
+- `POSTGRES_DSN`: string de conexão do PostgreSQL usada por `db.py` (sem valor padrão).
 
 ## Requisitos
 

--- a/reconhecimento_facial/db.py
+++ b/reconhecimento_facial/db.py
@@ -17,13 +17,19 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 
 logger = logging.getLogger(__name__)
 
-DSN = os.getenv("POSTGRES_DSN", "postgresql://user:pass@localhost:5432/face_db")
+DSN = os.getenv("POSTGRES_DSN")
+
+if not DSN:
+    logger.warning("POSTGRES_DSN not set; database features disabled")
 
 
 @contextmanager
 def get_conn():
-    if psycopg2 is None:
-        logger.error("psycopg2 not installed")
+    if psycopg2 is None or not DSN:
+        if psycopg2 is None:
+            logger.error("psycopg2 not installed")
+        else:
+            logger.error("POSTGRES_DSN not configured")
         yield None
         return
     conn = None


### PR DESCRIPTION
## Summary
- require POSTGRES_DSN environment variable for database access
- clarify in README that POSTGRES_DSN must be defined in `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857532574f0832aa4f5e3e7d5dea25f