### PR TITLE
Fix test deps and pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas 
 
 ## Testes
 
-Execute os testes automatizados com:
+Instale as dependências mínimas de testes e execute os testes automatizados com:
 
 ```bash
+pip install -r requirements-test.txt
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ face-app = "reconhecimento_facial.app:main"
 whisper-translate = "reconhecimento_facial.whisper_translation:main"
 
 [tool.pytest.ini_options]
-addopts = "-vv"
+addopts = "-p no:dash -vv"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+numpy
+opencv-python-headless


### PR DESCRIPTION
## Summary
- disable loading the `dash` plugin during pytest
- provide minimal requirements for running tests
- update README with instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685769a5f360832ab7b362858a24723e