### PR TITLE
Translate demographics labels to Portuguese

### DIFF
--- a/reconhecimento_facial/facexformer/inference.py
+++ b/reconhecimento_facial/facexformer/inference.py
@@ -34,8 +34,8 @@ AGE_LABELS = [
     "50-59",
     "60+",
 ]
-GENDER_LABELS = ["male", "female"]
-RACE_LABELS = ["white", "black", "asian", "indian", "other"]
+GENDER_LABELS = ["masculino", "feminino"]
+RACE_LABELS = ["branco", "negro", "asiático", "indiano", "outro"]
 
 # 40 CelebA attribute labels used by FaceXFormer
 ATTRIBUTE_LABELS = [


### PR DESCRIPTION
## Summary
- translate gender and race labels used in FaceXFormer to Portuguese

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576ae16f20832a838a733dd5c398ea