### PR TITLE
Fix translation fallback for English

### DIFF
--- a/reconhecimento_facial/whisper_translation.py
+++ b/reconhecimento_facial/whisper_translation.py
@@ -122,7 +122,9 @@ def translate_file(
     """Translate an audio file using Whisper and an optional translation model."""
 
     if target_lang == "en":
-        return _process_file(file_path, model_name, "translate", source_lang)
+        text = _process_file(file_path, model_name, "translate", source_lang)
+        if text:
+            return text
 
     text = _process_file(file_path, model_name, "transcribe", source_lang)
     if not text:


### PR DESCRIPTION
## Summary
- ensure translating to English falls back to text translation if Whisper fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685775e255cc832a90233ff535001f71