### PR TITLE
Fix FaceXFormer load on GPU

### DIFF
--- a/reconhecimento_facial/facexformer/inference.py
+++ b/reconhecimento_facial/facexformer/inference.py
@@ -132,13 +132,16 @@ def _load_model() -> None:
     except Exception as exc:  # noqa: BLE001
         logger.error("failed to download facexformer weights: %s", exc)
         return
-    model = FaceXFormer().to(device)
+
+    model = FaceXFormer()
     try:
-        checkpoint = torch.load(weight_path, map_location=device)
+        checkpoint = torch.load(weight_path, map_location="cpu")
         model.load_state_dict(checkpoint["state_dict_backbone"])
     except Exception as exc:  # noqa: BLE001
         logger.error("failed to load facexformer model: %s", exc)
         return
+
+    model.to(device)
     model.eval()
     _model = model
     _device = device


### PR DESCRIPTION
## Summary
- make FaceXFormer load the checkpoint on CPU first to avoid meta-tensor errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685779f1ba54832a90e6405dd174b8ea