### PR TITLE
Fix FaceXFormer global variable declaration

### DIFF
--- a/reconhecimento_facial/facexformer/inference.py
+++ b/reconhecimento_facial/facexformer/inference.py
@@ -168,6 +168,7 @@ def detect_demographics(image: Any) -> dict:
     image:
         Path to an image or an array (BGR) representing the image.
     """
+    global _device
     _load_model()
     if _model is None:
         raise RuntimeError("FaceXFormer model not available")
@@ -193,7 +194,6 @@ def detect_demographics(image: Any) -> dict:
                 torch.cuda.empty_cache()
             set_device("cpu")
             _model.to("cpu")
-            global _device
             _device = "cpu"
             tensor = _prepare_face(image)
             labels = {
@@ -243,6 +243,7 @@ def analyze_face(image: Any) -> dict:
     }
 
     def _run(tasks: torch.Tensor):
+        global _device
         nonlocal tensor, labels
         try:
             return _model(tensor, labels, tasks)
@@ -253,7 +254,6 @@ def analyze_face(image: Any) -> dict:
                     torch.cuda.empty_cache()
                 set_device("cpu")
                 _model.to("cpu")
-                global _device
                 _device = "cpu"
                 tensor = _prepare_face(image)
                 labels = {


### PR DESCRIPTION
## Summary
- fix syntax error by declaring `_device` global at the start of `detect_demographics`
- declare `_device` at the beginning of `_run` helper
- remove duplicate global statements

## Testing
- `python3 -m reconhecimento_facial.app` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6858691fc4c0832a8719c911b5b6e415