### PR TITLE
Add automated social search after face recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Você também pode executar comandos específicos diretamente pela CLI:
 python3 -m reconhecimento_facial.face_detection --image caminho/para/imagem.jpg --output saida.jpg
 python3 -m reconhecimento_facial.app detect --image caminho/para/imagem.jpg --model yolov8
 python3 -m reconhecimento_facial.recognition --webcam
+python3 -m reconhecimento_facial.recognition --image foto.jpg --social-search --site facebook
 python3 -m reconhecimento_facial.whisper_translation --model openai/whisper-large-v3-turbo --chunk 5 --src pt --webcam
 python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --src pt --expected "texto esperado"
 python3 -m reconhecimento_facial.whisper_translation --file caminho/para/audio.wav --transcribe --src pt
@@ -74,6 +75,7 @@ O programa principal (`app.py`) apresenta quatro categorias principais:
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
 - É possível escolher o idioma de entrada e o de saída para tradução.
 - Busca de perfis em redes sociais utilizando o `social_mapper` (via script `social-search`).
+- Reconhecimento de rostos com busca automática em redes sociais usando a flag `--social-search`.
 
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`. A variável `POSTGRES_DSN` **deve** ser definida nesse arquivo caso queira usar o banco de dados.
 

--- a/reconhecimento_facial/social_search.py
+++ b/reconhecimento_facial/social_search.py
@@ -34,8 +34,11 @@ def run_social_search(
     sites: Iterable[str] = ("facebook",),
     fast: bool = True,
     repo_path: str | None = None,
-) -> None:
-    """Run social_mapper to search for a face on social networks."""
+) -> Path:
+    """Run social_mapper to search for a face on social networks.
+
+    Returns the path to the ``SM-Results`` directory created by the tool.
+    """
     repo = ensure_repo(repo_path)
     img_dir = repo / "input-images"
     if img_dir.exists():
@@ -62,6 +65,7 @@ def run_social_search(
 
     logger.info("Running social_mapper: %s", " ".join(cmd))
     subprocess.run(cmd, check=True, cwd=str(repo))
+    return repo / "SM-Results"
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/tests/test_recognition_social.py
+++ b/tests/test_recognition_social.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _prepare_modules(monkeypatch):
+    dummy_fx = types.ModuleType('facexformer')
+    dummy_fx.analyze_face = lambda img: {}
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer', dummy_fx)
+
+    dummy_dem = types.ModuleType('demographics_detection')
+    dummy_dem.detect_demographics = lambda img: {}
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.demographics_detection', dummy_dem)
+
+    dummy_db = types.ModuleType('db')
+    dummy_db.get_conn = lambda: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s, exc, val, tb: None)
+    dummy_db.init_db = lambda: None
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.db', dummy_db)
+
+
+def import_rec(monkeypatch):
+    _prepare_modules(monkeypatch)
+    import importlib
+    return importlib.import_module('reconhecimento_facial.recognition')
+
+
+def test_recognize_faces_social(monkeypatch):
+    rec = import_rec(monkeypatch)
+    called = {}
+    monkeypatch.setattr(rec, 'recognize_faces', lambda img: ['Alice'])
+
+    def dummy_thread(target, args=(), kwargs=None, daemon=None):
+        called['args'] = args
+        target(*args, **(kwargs or {}))
+        return types.SimpleNamespace(start=lambda: None)
+
+    monkeypatch.setattr(rec.threading, 'Thread', dummy_thread)
+    monkeypatch.setattr(rec, '_social_search_background', lambda *a, **k: called.update({'bg': a}))
+
+    names = rec.recognize_faces_social('img.jpg', sites=['facebook'])
+    assert names == ['Alice']
+    assert called['bg'][1] == 'Alice'

--- a/tests/test_social_search.py
+++ b/tests/test_social_search.py
@@ -23,8 +23,9 @@ def test_run_social_search(monkeypatch, tmp_path):
     img = tmp_path / "img.jpg"
     img.write_text("dummy")
 
-    ss.run_social_search([str(img)], sites=['facebook'])
+    out = ss.run_social_search([str(img)], sites=['facebook'])
 
     assert 'social_mapper.py' in called['cmd'][1]
     assert called['cwd'] == str(tmp_path)
+    assert out == tmp_path / 'SM-Results'
 


### PR DESCRIPTION
## Summary
- return results folder path from `run_social_search`
- integrate background social search with face recognition
- allow webcam recognition to trigger social search
- expose `--social-search` CLI option
- document new feature in README
- test new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586c95cdc8832a877720c7a144bad8