### PR TITLE
Enable social search on webcam registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ O programa principal (`app.py`) apresenta quatro categorias principais:
 - É possível escolher o idioma de entrada e o de saída para tradução.
 - Busca de perfis em redes sociais utilizando o Social Mapper integrado (`social-search`).
 - Reconhecimento de rostos com busca automática em redes sociais usando a flag `--social-search`.
+- Cadastro de pessoas pela webcam com opção de buscar o rosto nas redes sociais.
 
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`. A variável `POSTGRES_DSN` **deve** ser definida nesse arquivo caso queira usar o banco de dados.
 

--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -201,8 +201,11 @@ def menu() -> None:
             _recognition_menu()
         elif choice == main_opts[2]:
             name = input("Nome da pessoa: ").strip()
+            social = questionary.confirm(
+                "Buscar rosto nas redes sociais?"
+            ).ask()
             try:
-                if register_person_webcam(name):
+                if register_person_webcam(name, social_search=bool(social)):
                     time.sleep(2)
                 else:
                     print("Erro ao cadastrar pessoa")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _prepare_modules(monkeypatch):
+    dummy_fx = types.ModuleType('facexformer')
+    dummy_fx.analyze_face = lambda img: {}
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer', dummy_fx)
+
+    dummy_dem = types.ModuleType('demographics_detection')
+    dummy_dem.detect_demographics = lambda img: {}
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.demographics_detection', dummy_dem)
+
+    dummy_db = types.ModuleType('db')
+    dummy_db.get_conn = lambda: types.SimpleNamespace(__enter__=lambda s: None, __exit__=lambda s, exc, val, tb: None)
+    dummy_db.init_db = lambda: None
+    monkeypatch.setitem(sys.modules, 'reconhecimento_facial.db', dummy_db)
+
+
+def import_rec(monkeypatch):
+    _prepare_modules(monkeypatch)
+    import importlib
+    return importlib.import_module('reconhecimento_facial.recognition')
+
+
+def test_register_person_webcam_social(monkeypatch):
+    rec = import_rec(monkeypatch)
+    called = {}
+    monkeypatch.setattr(rec, 'capture_from_webcam', lambda p: True)
+    monkeypatch.setattr(rec, 'register_person', lambda n, p: True)
+
+    def dummy_thread(target, args=(), kwargs=None, daemon=None):
+        called['args'] = args
+        target(*args)
+        return types.SimpleNamespace(start=lambda: None)
+
+    monkeypatch.setattr(rec.threading, 'Thread', dummy_thread)
+    monkeypatch.setattr(rec, '_social_search_background', lambda *a: called.update({'bg': a}))
+
+    ok = rec.register_person_webcam('Alice', social_search=True, sites=['fb'])
+    assert ok
+    assert called['bg'][1] == 'Alice'
+


### PR DESCRIPTION
## Summary
- search social networks when registering a person via webcam
- ask in interactive menu whether to search when registering
- document webcam registration search feature
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858764af508832aa5ab5084df09a02d