### PR TITLE
Add toggle for real-time translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ O programa principal (`app.py`) apresenta quatro categorias principais:
 - `PHOTOS_DIR`: pasta onde ficam as fotos capturadas.
 - Interface web em Flask e Dockerfile para facilitar a execução.
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
+- O menu principal permite ativar ou desativar essa tradução a qualquer momento.
 - É possível escolher o idioma de entrada e o de saída para tradução.
 - Busca de perfis em imagens locais através do recurso `social-search`.
 - Reconhecimento de rostos com busca automática em redes sociais (o menu já inicia a busca por padrão).


### PR DESCRIPTION
## Summary
- allow recognition menu to run without translation
- add option in main menu to toggle real-time audio translation
- document new menu option in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6859665fc220832a9c41274817619bf0