### PR TITLE
Remove translation toggle from main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ O programa principal (`app.py`) apresenta quatro categorias principais:
 - `PHOTOS_DIR`: pasta onde ficam as fotos capturadas.
 - Interface web em Flask e Dockerfile para facilitar a execução.
 - Tradução de fala em tempo real via OpenAI Whisper (use `--webcam` para traduzir enquanto a webcam está aberta).
-- O menu principal permite ativar ou desativar essa tradução a qualquer momento.
+- A tradução pode ser ativada ou desativada a qualquer momento no menu **Outros**.
 - É possível escolher o idioma de entrada e o de saída para tradução.
 - Busca de perfis em imagens locais através do recurso `social-search`.
 - Reconhecimento de rostos com busca automática em redes sociais (o menu já inicia a busca por padrão).

--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -212,11 +212,6 @@ def menu() -> None:
             "Reconhecimento",
             "Cadastrar pessoa (face_recognition)",
             "Outros",
-            (
-                "Desativar tradução em tempo real"
-                if _translation_enabled
-                else "Ativar tradução em tempo real"
-            ),
             "Sair",
         ]
         os.system("cls" if os.name == "nt" else "clear")
@@ -242,11 +237,6 @@ def menu() -> None:
                 print(f"Erro ao cadastrar: {exc}")
         elif choice == main_opts[3]:
             _other_menu()
-        elif choice == main_opts[4]:
-            _translation_enabled = not _translation_enabled
-            status = "ativada" if _translation_enabled else "desativada"
-            print(f"Tradução {status}")
-            time.sleep(1)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- remove translation toggle from the main menu, keeping it only under *Outros*
- update README to explain how to toggle translation

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859694ff128832a80e04facd457c80e