### PR TITLE
Fix cropped image naming

### DIFF
--- a/reconhecimento_facial/recognition.py
+++ b/reconhecimento_facial/recognition.py
@@ -99,7 +99,7 @@ def _crop_and_save_face(image_path: str) -> None:
 
 def _save_cropped_face(crop: np.ndarray, name: str, tech: str) -> Path:
     """Save cropped face image using standardized naming."""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now().strftime("%d_%m_%Y")
     clean_name = name.replace(" ", "_") or "Unknown"
     filename = f"{clean_name}_{timestamp}_{tech}.jpg"
     out_path = Path(PHOTOS_DIR) / filename


### PR DESCRIPTION
## Summary
- remove hour from timestamp when saving cropped faces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68596d467d8c832abee002f440d033fd