### PR TITLE
Use FaceXFormer for registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ O programa principal (`app.py`) apresenta quatro categorias principais:
 
 1. **Detecção** – identifica rostos (inclusive via webcam) ou obstruções nas imagens.
 2. **Reconhecimento** – para realizar reconhecimento facial ou exibir demografia via webcam.
-3. **Cadastrar pessoa** – registra uma nova pessoa utilizando a webcam.
+3. **Cadastrar pessoa** – registra uma nova pessoa utilizando a webcam com FaceXFormer.
 4. **Outros** – onde é possível gerar legendas para imagens usando um modelo de linguagem.
 
 ## Funcionalidades

--- a/reconhecimento_facial/app.py
+++ b/reconhecimento_facial/app.py
@@ -21,7 +21,7 @@ from reconhecimento_facial.llm_service import generate_caption
 from reconhecimento_facial.obstruction_detection import detect_obstruction
 from reconhecimento_facial.recognition import (
     recognize_webcam,
-    register_person_webcam,
+    register_person_webcam_facexformer,
     demographics_webcam,
     recognize_webcam_mediapipe,
 )
@@ -206,7 +206,7 @@ def menu() -> None:
         main_opts = [
             "Detecção",
             "Reconhecimento",
-            "Cadastrar pessoa (face_recognition)",
+            "Cadastrar pessoa (FaceXFormer)",
             "Outros",
             "Sair",
         ]
@@ -222,7 +222,7 @@ def menu() -> None:
         elif choice == main_opts[2]:
             name = input("Nome da pessoa: ").strip()
             try:
-                if register_person_webcam(name):
+                if register_person_webcam_facexformer(name):
                     time.sleep(2)
                 else:
                     print("Erro ao cadastrar pessoa")

--- a/reconhecimento_facial/facexformer/__init__.py
+++ b/reconhecimento_facial/facexformer/__init__.py
@@ -1,5 +1,5 @@
 """Minimal FaceXFormer integration for demographics detection."""
 
-from .inference import analyze_face, detect_demographics
+from .inference import analyze_face, detect_demographics, extract_embedding
 
-__all__ = ["detect_demographics", "analyze_face"]
+__all__ = ["detect_demographics", "analyze_face", "extract_embedding"]

--- a/reconhecimento_facial/facexformer/inference.py
+++ b/reconhecimento_facial/facexformer/inference.py
@@ -321,3 +321,15 @@ def analyze_face(image: Any) -> dict:
     result["visibility"] = int(vis.argmax(dim=1).item())
 
     return result
+
+
+def extract_embedding(image: Any) -> np.ndarray:
+    """Return a face embedding vector using the FaceXFormer backbone."""
+    _load_model()
+    if _model is None:
+        raise RuntimeError("FaceXFormer model not available")
+    tensor = _prepare_face(image)
+    with torch.no_grad():
+        _model.multi_scale_features.clear()
+        emb = _model.backbone(tensor).squeeze()
+    return emb.cpu().numpy()

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -12,6 +12,7 @@ def test_detect_demographics_facexformer(monkeypatch):
     dummy.detect_demographics = lambda img: {
         'gender': 'male', 'age': '30', 'ethnicity': 'asian', 'skin': 'light'
     }
+    dummy.extract_embedding = lambda img: b""
     monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer.inference', dummy)
     result = dd.detect_demographics('any.jpg')
     assert result == {
@@ -31,6 +32,7 @@ def test_detect_demographics_array(monkeypatch):
         return {'gender': 'female'}
 
     dummy.detect_demographics = _detect
+    dummy.extract_embedding = lambda img: b""
     monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer.inference', dummy)
     result = dd.detect_demographics(arr)
     assert result == {'gender': 'female'}
@@ -53,6 +55,7 @@ def test_analyze_face(monkeypatch):
 
     dummy.analyze_face = _analyze
     dummy.detect_demographics = lambda img: {}
+    dummy.extract_embedding = lambda img: b""
     monkeypatch.setitem(sys.modules, 'reconhecimento_facial.facexformer.inference', dummy)
     sys.modules.pop('reconhecimento_facial.facexformer', None)
     from reconhecimento_facial.facexformer import analyze_face

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 dummy_fx = types.ModuleType("facexformer")
 dummy_fx.analyze_face = lambda img: {}
+dummy_fx.extract_embedding = lambda img: b""
 sys.modules["reconhecimento_facial.facexformer"] = dummy_fx
 dummy_dem = types.ModuleType("demographics_detection")
 dummy_dem.detect_demographics = lambda img: {}

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 def _prepare_modules(monkeypatch):
     dummy_fx = types.ModuleType("facexformer")
     dummy_fx.analyze_face = lambda img: {}
+    dummy_fx.extract_embedding = lambda img: b""
     monkeypatch.setitem(sys.modules, "reconhecimento_facial.facexformer", dummy_fx)
 
     dummy_dem = types.ModuleType("demographics_detection")


### PR DESCRIPTION
## Summary
- register people using FaceXFormer embeddings
- expose `extract_embedding` helper
- call FaceXFormer registration from the main menu
- update tests to support new import
- document the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859aa6c3730832ab89893004054e404