### PR TITLE
Fix user photo persistence

### DIFF
--- a/reconhecimento_facial/db.py
+++ b/reconhecimento_facial/db.py
@@ -69,10 +69,12 @@ def init_db() -> None:
             CREATE TABLE IF NOT EXISTS people (
                 id SERIAL PRIMARY KEY,
                 name TEXT,
-                embedding BYTEA
+                embedding BYTEA,
+                photo TEXT
             );
             """
         )
+        cur.execute("ALTER TABLE people ADD COLUMN IF NOT EXISTS photo TEXT")
         conn.commit()
 
 
@@ -86,3 +88,13 @@ def save_detection(image: str, faces: int, caption: str = "", obstruction: str =
             (image, faces, caption, obstruction, recognized, extras.Json(result_json) if extras else None),
         )
         conn.commit()
+
+
+def get_people() -> list[tuple[str, str]]:
+    """Return list of registered people as ``(name, photo)``."""
+    with get_conn() as conn:
+        if conn is None:
+            return []
+        cur = conn.cursor()
+        cur.execute("SELECT name, photo FROM people")
+        return cur.fetchall()

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -35,8 +35,17 @@ def import_rec(monkeypatch):
 def test_register_person_webcam_social(monkeypatch):
     rec = import_rec(monkeypatch)
     called = {}
-    monkeypatch.setattr(rec, "capture_from_webcam", lambda p: True)
-    monkeypatch.setattr(rec, "register_person", lambda n, p: True)
+
+    monkeypatch.setattr(rec, "capture_from_webcam", lambda p: "face.jpg")
+
+    def _reg(name, img):
+        called["name"] = name
+        called["img"] = img
+        return True
+
+    monkeypatch.setattr(rec, "register_person", _reg)
 
     ok = rec.register_person_webcam("Alice")
     assert ok
+    assert called["name"] == "Alice"
+    assert called["img"] == "face.jpg"


### PR DESCRIPTION
## Summary
- include `photo` column for `people` table
- return the cropped face path when capturing from webcam
- store cropped photo path during registration
- expose a helper to list registered people
- adjust unit test to new behaviour

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859baf94564832a9ff2aba7edbe053e