### PR TITLE
Add web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ curl http://localhost:8000/people
 curl http://localhost:8000/detections
 ```
 
+Também é possível acessar uma interface gráfica completa via navegador em
+`http://localhost:8000/`. Todas as funcionalidades disponíveis na linha de
+comando podem ser acessadas por essa página inicial.
+
 Copie o arquivo `.env.example` para `.env` e ajuste conforme necessário. Todas as dependências podem ser instaladas utilizando o `pyproject.toml`. A variável `POSTGRES_DSN` **deve** ser definida nesse arquivo caso queira usar o banco de dados.
 
 ## Variáveis de ambiente

--- a/reconhecimento_facial/templates/base.html
+++ b/reconhecimento_facial/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Reconhecimento Facial</title>
+</head>
+<body>
+<h1>Reconhecimento Facial</h1>
+<nav>
+    <a href="/">Início</a> |
+    <a href="/detect">Detecção</a> |
+    <a href="/caption">Legenda</a> |
+    <a href="/obstruction">Obstrução</a> |
+    <a href="/register">Cadastrar Pessoa</a> |
+    <a href="/people_view">Pessoas</a> |
+    <a href="/detections_view">Detecções</a>
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/reconhecimento_facial/templates/caption.html
+++ b/reconhecimento_facial/templates/caption.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+    <p>Imagem: <input type="file" name="image" required></p>
+    <button type="submit">Gerar legenda</button>
+</form>
+{% if caption %}<p>Legenda: {{ caption }}</p>{% endif %}
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+{% endblock %}

--- a/reconhecimento_facial/templates/detect.html
+++ b/reconhecimento_facial/templates/detect.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+    <p>Imagem: <input type="file" name="image" required></p>
+    <p>
+        Modelo:
+        <select name="model">
+            <option value="opencv">OpenCV</option>
+            <option value="mediapipe">MediaPipe</option>
+            <option value="yolov8">YOLOv8</option>
+        </select>
+    </p>
+    <button type="submit">Detectar</button>
+</form>
+{% if faces is not none %}
+<p>{{ faces }} rosto(s) detectado(s) usando {{ model }}.</p>
+<img src="data:image/jpeg;base64,{{ image }}" alt="Resultado">
+{% endif %}
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+{% endblock %}

--- a/reconhecimento_facial/templates/detections.html
+++ b/reconhecimento_facial/templates/detections.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Últimas detecções</h2>
+<table border="1">
+<tr><th>ID</th><th>Imagem</th><th>Rostos</th><th>Legenda</th><th>Obstrução</th><th>Reconhecidos</th></tr>
+{% for d in detections %}
+<tr>
+    <td>{{ d[0] }}</td>
+    <td>{{ d[1] }}</td>
+    <td>{{ d[2] }}</td>
+    <td>{{ d[3] }}</td>
+    <td>{{ d[4] }}</td>
+    <td>{{ d[5] }}</td>
+</tr>
+{% else %}
+<tr><td colspan="6">Nenhuma detecção</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/reconhecimento_facial/templates/index.html
+++ b/reconhecimento_facial/templates/index.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<p>Escolha uma funcionalidade no menu acima.</p>
+{% endblock %}

--- a/reconhecimento_facial/templates/obstruction.html
+++ b/reconhecimento_facial/templates/obstruction.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+    <p>Imagem: <input type="file" name="image" required></p>
+    <button type="submit">Detectar obstrução</button>
+</form>
+{% if label %}<p>Obstrução: {{ label }}</p>{% endif %}
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+{% endblock %}

--- a/reconhecimento_facial/templates/people.html
+++ b/reconhecimento_facial/templates/people.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Pessoas cadastradas</h2>
+<ul>
+{% for n in names %}<li>{{ n }}</li>{% else %}<li>Nenhuma pessoa cadastrada</li>{% endfor %}
+</ul>
+{% endblock %}

--- a/reconhecimento_facial/templates/register.html
+++ b/reconhecimento_facial/templates/register.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+    <p>Nome: <input type="text" name="name" required></p>
+    <p>Foto: <input type="file" name="image" required></p>
+    <button type="submit">Cadastrar</button>
+</form>
+{% if success is not none %}
+<p>{{ 'Cadastro realizado com sucesso' if success else 'Falha ao cadastrar' }}</p>
+{% endif %}
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+{% endblock %}

--- a/reconhecimento_facial/web_app.py
+++ b/reconhecimento_facial/web_app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 
 if __package__ is None or __package__ == "":
     import pathlib
@@ -7,12 +7,47 @@ if __package__ is None or __package__ == "":
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
     __package__ = "reconhecimento_facial"
 
-from reconhecimento_facial.face_detection import detect_faces
-from reconhecimento_facial.llm_service import generate_caption
-from reconhecimento_facial.obstruction_detection import detect_obstruction
-from reconhecimento_facial.db import list_people, list_detections
+# Heavy modules are imported lazily inside the helper wrappers below to avoid
+# importing optional dependencies when this module is imported during tests.
+
+def detect_faces(*args, **kwargs):  # noqa: D401 - wrapper for lazy import
+    """Call :func:`face_detection.detect_faces` lazily."""
+    from reconhecimento_facial.face_detection import detect_faces as _df
+
+    return _df(*args, **kwargs)
+
+
+def generate_caption(*args, **kwargs):  # noqa: D401 - wrapper for lazy import
+    """Call :func:`llm_service.generate_caption` lazily."""
+    from reconhecimento_facial.llm_service import generate_caption as _gc
+
+    return _gc(*args, **kwargs)
+
+
+def detect_obstruction(*args, **kwargs):  # noqa: D401 - wrapper for lazy import
+    """Call :func:`obstruction_detection.detect_obstruction` lazily."""
+    from reconhecimento_facial.obstruction_detection import (
+        detect_obstruction as _do,
+    )
+
+    return _do(*args, **kwargs)
+
+
+def list_people():  # noqa: D401 - wrapper for lazy import
+    """Call :func:`db.list_people` lazily."""
+    from reconhecimento_facial.db import list_people as _lp
+
+    return _lp()
+
+
+def list_detections(limit: int = 100):  # noqa: D401 - wrapper for lazy import
+    """Call :func:`db.list_detections` lazily."""
+    from reconhecimento_facial.db import list_detections as _ld
+
+    return _ld(limit)
 
 app = Flask(__name__)
+app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 
 @app.route('/process', methods=['POST'])
@@ -26,6 +61,99 @@ def process():
     caption = generate_caption(path)
     obstruction = detect_obstruction(path)
     return jsonify({'faces': faces, 'caption': caption, 'obstruction': obstruction})
+
+
+@app.route('/')
+def index() -> str:
+    """Display the home page with links to all actions."""
+    return render_template('index.html')
+
+
+@app.route('/detect', methods=['GET', 'POST'])
+def detect_page() -> str:
+    """Upload an image and run face detection."""
+    if request.method == 'POST':
+        file = request.files.get('image')
+        model = request.form.get('model', 'opencv')
+        if not file:
+            return render_template('detect.html', error='Selecione uma imagem')
+        img_path = '/tmp/input.jpg'
+        out_path = '/tmp/output.jpg'
+        file.save(img_path)
+        use_hf = model in ('mediapipe', 'yolov8')
+        faces = detect_faces(img_path, out_path, use_hf=use_hf, hf_model=model)
+        with open(out_path, 'rb') as fh:
+            import base64
+
+            encoded = base64.b64encode(fh.read()).decode('utf-8')
+        return render_template(
+            'detect.html',
+            faces=faces,
+            model=model,
+            image=encoded,
+        )
+    return render_template('detect.html')
+
+
+@app.route('/caption', methods=['GET', 'POST'])
+def caption_page() -> str:
+    """Generate an image caption using the LLM service."""
+    if request.method == 'POST':
+        file = request.files.get('image')
+        if not file:
+            return render_template('caption.html', error='Selecione uma imagem')
+        img_path = '/tmp/caption.jpg'
+        file.save(img_path)
+        caption = generate_caption(img_path)
+        return render_template('caption.html', caption=caption)
+    return render_template('caption.html')
+
+
+@app.route('/obstruction', methods=['GET', 'POST'])
+def obstruction_page() -> str:
+    """Detect face obstruction in an image."""
+    if request.method == 'POST':
+        file = request.files.get('image')
+        if not file:
+            return render_template(
+                'obstruction.html', error='Selecione uma imagem'
+            )
+        img_path = '/tmp/obstruction.jpg'
+        file.save(img_path)
+        label = detect_obstruction(img_path)
+        return render_template('obstruction.html', label=label)
+    return render_template('obstruction.html')
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register_page() -> str:
+    """Register a person by uploading a photo."""
+    if request.method == 'POST':
+        file = request.files.get('image')
+        name = request.form.get('name', '').strip()
+        if not file or not name:
+            return render_template('register.html', error='Informe nome e imagem')
+        img_path = '/tmp/register.jpg'
+        file.save(img_path)
+        from reconhecimento_facial.recognition import register_person_cli
+
+        ok = register_person_cli(img_path, name)
+        return render_template('register.html', success=ok)
+    return render_template('register.html')
+
+
+@app.route('/people_view')
+def people_view() -> str:
+    """Show people registered in the database."""
+    names = list_people()
+    return render_template('people.html', names=names)
+
+
+@app.route('/detections_view')
+def detections_view() -> str:
+    """Display recent detections stored in the database."""
+    rows = list_detections(20)
+    return render_template('detections.html', detections=rows)
 
 
 @app.route('/people', methods=['GET'])


### PR DESCRIPTION
## Summary
- lazy-load heavy modules in web_app to avoid optional deps during import
- extend Flask app with new pages for detection, caption, obstruction, people and detections
- add simple HTML templates for the web interface
- document new interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1b92a398832ab3bf3f1bac9d9258