### PR TITLE
Add browser webcam support

### DIFF
--- a/reconhecimento_facial/templates/base.html
+++ b/reconhecimento_facial/templates/base.html
@@ -26,6 +26,7 @@
         <summary>Reconhecimento</summary>
         <ul>
             <li><a href="/recognize">Reconhecer imagem</a></li>
+            <li><a href="/webcam">Webcam</a></li>
         </ul>
     </details>
     <details>

--- a/reconhecimento_facial/templates/webcam.html
+++ b/reconhecimento_facial/templates/webcam.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<video id="video" width="640" height="480" autoplay></video>
+<br>
+<button id="capture">Capturar</button>
+<p id="result"></p>
+<script>
+const video = document.getElementById('video');
+navigator.mediaDevices.getUserMedia({ video: true })
+  .then(stream => { video.srcObject = stream; })
+  .catch(err => { console.error('webcam error', err); });
+
+document.getElementById('capture').onclick = () => {
+  const canvas = document.createElement('canvas');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  canvas.getContext('2d').drawImage(video, 0, 0);
+  canvas.toBlob(blob => {
+    const data = new FormData();
+    data.append('image', blob, 'capture.jpg');
+    fetch('/recognize_api', { method: 'POST', body: data })
+      .then(r => r.json())
+      .then(j => { document.getElementById('result').innerText = (j.names || []).join(', '); })
+      .catch(() => { document.getElementById('result').innerText = 'erro'; });
+  }, 'image/jpeg');
+};
+</script>
+{% endblock %}

--- a/reconhecimento_facial/web_app.py
+++ b/reconhecimento_facial/web_app.py
@@ -141,6 +141,20 @@ def recognize_page() -> str:
     return render_template('recognize.html')
 
 
+@app.route('/recognize_api', methods=['POST'])
+def recognize_api():
+    """Recognize faces and return JSON."""
+    file = request.files.get('image')
+    if not file:
+        return {'error': 'no file'}, 400
+    img_path = '/tmp/recognize.jpg'
+    file.save(img_path)
+    from reconhecimento_facial.recognition import recognize_faces
+
+    names = recognize_faces(img_path)
+    return jsonify({'names': names})
+
+
 @app.route('/register', methods=['GET', 'POST'])
 def register_page() -> str:
     """Register a person by uploading a photo."""
@@ -156,6 +170,12 @@ def register_page() -> str:
         ok = register_person_cli(img_path, name)
         return render_template('register.html', success=ok)
     return render_template('register.html')
+
+
+@app.route('/webcam')
+def webcam_page() -> str:
+    """Display a simple webcam interface."""
+    return render_template('webcam.html')
 
 
 @app.route('/people_view')

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -19,3 +19,25 @@ def test_detections_route(monkeypatch):
     client = web.app.test_client()
     resp = client.get("/detections")
     assert resp.json[0]["id"] == 1
+
+
+def test_recognize_api(monkeypatch, tmp_path):
+    dummy = types.ModuleType("rec")
+    dummy.recognize_faces = lambda p: ["Bob"]
+    monkeypatch.setitem(sys.modules, "reconhecimento_facial.recognition", dummy)
+    client = web.app.test_client()
+    img = tmp_path / "img.jpg"
+    img.write_bytes(b"data")
+    with img.open("rb") as fh:
+        resp = client.post(
+            "/recognize_api",
+            data={"image": (fh, "img.jpg")},
+            content_type="multipart/form-data",
+        )
+    assert resp.json == {"names": ["Bob"]}
+
+
+def test_webcam_page():
+    client = web.app.test_client()
+    resp = client.get("/webcam")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add link to webcam in nav
- create webcam page with capture script
- expose `/recognize_api` endpoint
- add `/webcam` route
- extend web tests for new routes

## Testing
- `pip install -r requirements-test.txt`
- `pip install flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1e95a8a8832a8b59ca58aa87fa1c