### PR TITLE
Enhance webcam FaceXFormer output

### DIFF
--- a/reconhecimento_facial/templates/webcam.html
+++ b/reconhecimento_facial/templates/webcam.html
@@ -1,9 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
-<video id="video" width="640" height="480" autoplay></video>
+<div style="position:relative; display:inline-block;">
+  <video id="video" width="640" height="480" autoplay></video>
+  <canvas id="overlay" style="position:absolute; top:0; left:0;"></canvas>
+</div>
 <br>
 <button id="capture">Iniciar</button>
 <p id="result"></p>
+<pre id="fxdata" style="white-space: pre-wrap;"></pre>
 <script>
 const video = document.getElementById('video');
 navigator.mediaDevices.getUserMedia({ video: true })
@@ -20,7 +24,28 @@ function capture() {
     data.append('image', blob, 'capture.jpg');
     fetch('/recognize_api', { method: 'POST', body: data })
       .then(r => r.json())
-      .then(j => { document.getElementById('result').innerText = (j.names || []).join(', '); })
+      .then(j => {
+        document.getElementById('result').innerText = (j.names || []).join(', ');
+        const ctx = document.getElementById('overlay').getContext('2d');
+        ctx.canvas.width = video.videoWidth;
+        ctx.canvas.height = video.videoHeight;
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        const info = [];
+        (j.faces || []).forEach(face => {
+          const [top, right, bottom, left] = face.box;
+          ctx.strokeStyle = 'green';
+          ctx.lineWidth = 2;
+          ctx.strokeRect(left, top, right - left, bottom - top);
+          ctx.fillStyle = 'green';
+          ctx.font = '16px sans-serif';
+          ctx.fillText(face.name, left, top - 5);
+          const d = face.analysis || {};
+          const details = [d.gender, d.age, d.ethnicity, d.skin].filter(Boolean).join(', ');
+          if (details) ctx.fillText(details, left, top + 15);
+          info.push(JSON.stringify(face.analysis));
+        });
+        document.getElementById('fxdata').innerText = info.join('\n');
+      })
       .catch(() => { document.getElementById('result').innerText = 'erro'; });
   }, 'image/jpeg');
 }

--- a/reconhecimento_facial/web_app.py
+++ b/reconhecimento_facial/web_app.py
@@ -232,10 +232,11 @@ def recognize_api():
         return {'error': 'no file'}, 400
     img_path = '/tmp/recognize.jpg'
     file.save(img_path)
-    from reconhecimento_facial.recognition import recognize_faces
+    from reconhecimento_facial.recognition import recognize_faces_with_analysis
 
-    names = recognize_faces(img_path)
-    return jsonify({'names': names})
+    faces = recognize_faces_with_analysis(img_path)
+    names = [f['name'] for f in faces]
+    return jsonify({'names': names, 'faces': faces})
 
 @app.route('/register_api', methods=['POST'])
 def register_api():

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -23,7 +23,9 @@ def test_detections_route(monkeypatch):
 
 def test_recognize_api(monkeypatch, tmp_path):
     dummy = types.ModuleType("rec")
-    dummy.recognize_faces = lambda p: ["Bob"]
+    dummy.recognize_faces_with_analysis = lambda p: [
+        {"box": [0, 1, 2, 3], "name": "Bob", "analysis": {"gender": "m"}}
+    ]
     monkeypatch.setitem(sys.modules, "reconhecimento_facial.recognition", dummy)
     client = web.app.test_client()
     img = tmp_path / "img.jpg"
@@ -34,7 +36,8 @@ def test_recognize_api(monkeypatch, tmp_path):
             data={"image": (fh, "img.jpg")},
             content_type="multipart/form-data",
         )
-    assert resp.json == {"names": ["Bob"]}
+    assert resp.json["names"] == ["Bob"]
+    assert resp.json["faces"][0]["box"] == [0, 1, 2, 3]
 
 
 def test_webcam_page():


### PR DESCRIPTION
## Summary
- expand `/recognize_api` to return bounding boxes and FaceXFormer analysis
- draw green face boxes and show facexformer details in the webcam page
- expose `recognize_faces_with_analysis` in recognition module
- adjust web tests for new API response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c40bb700c832aae670957b839cbd0